### PR TITLE
Undefined name: Typo access_addres --> access_address (add a trailing s)

### DIFF
--- a/btlejack/link.py
+++ b/btlejack/link.py
@@ -6,12 +6,13 @@ from serial import Serial
 from serial.tools.list_ports import comports
 from struct import pack, unpack
 from threading import Lock
-from btlejack.packets import Packet, PacketRegistry, ResetCommand, VersionCommand, \
-    ScanConnectionsCommand, RecoverConnectionCommand, ResetResponse, \
-    VersionResponse, ScanConnectionsResponse, AccessAddressNotification, \
-    RecoverConnectionResponse, SniffConnReqCommand, SniffConnReqResponse, \
-    ConnectionRequestNotification, EnableJammingCommand, EnableJammingResponse, \
-    EnableHijackingCommand, EnableHijackingResponse
+from btlejack.packets import (Packet, PacketRegistry, ResetCommand, VersionCommand,
+    ScanConnectionsCommand, RecoverConnectionCommand, ResetResponse,
+    VersionResponse, ScanConnectionsResponse, AccessAddressNotification,
+    RecoverConnectionResponse, SniffConnReqCommand, SniffConnReqResponse,
+    ConnectionRequestNotification, EnableJammingCommand, EnableJammingResponse,
+    EnableHijackingCommand, EnableHijackingResponse, RecoverCrcInitCommand,
+    RecoverResponse)
 
 
 class DeviceError(Exception):

--- a/btlejack/session.py
+++ b/btlejack/session.py
@@ -69,7 +69,7 @@ class BtlejackSession:
         """
         Remove a given connection from the session.
         """
-        if access_addres in self.connections:
+        if access_address in self.connections:
             del self.connections[access_address]
 
     def clear(self):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/virtualabs/btlejack on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./btlejack/session.py:72:12: F821 undefined name 'access_addres'
        if access_addres in self.connections:
           ^
./btlejack/link.py:190:20: F821 undefined name 'RecoverCrcInitCommand'
        self.write(RecoverCrcInitCommand(access_address, channel_map, hop_interval))
                   ^
./btlejack/link.py:191:26: F821 undefined name 'RecoverResponse'
        self.wait_packet(RecoverResponse)
                         ^
3     F821 undefined name 'RecoverCrcInitCommand'
3
```