### PR TITLE
from btlejack.packets import RecoverResponse

### DIFF
--- a/btlejack/link.py
+++ b/btlejack/link.py
@@ -8,7 +8,7 @@ from struct import pack, unpack
 from threading import Lock
 from btlejack.packets import (Packet, PacketRegistry, ResetCommand,
     VersionCommand, ScanConnectionsCommand, RecoverCrcInitCommand,
-    ResetResponse, VersionResponse, ScanConnectionsResponse,
+    RecoverResponse, ResetResponse, VersionResponse, ScanConnectionsResponse,
     AccessAddressNotification, SniffConnReqCommand, SniffConnReqResponse,
     ConnectionRequestNotification, EnableJammingCommand, EnableJammingResponse,
     EnableHijackingCommand, EnableHijackingResponse)


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/virtualabs/btlejack on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./btlejack/link.py:190:26: F821 undefined name 'RecoverResponse'
        self.wait_packet(RecoverResponse)
                         ^
1     F821 undefined name 'RecoverResponse'
1
```