### PR TITLE
Comports returning list of tuples on Linux Python 3.4

### DIFF
--- a/btlejack/jobs.py
+++ b/btlejack/jobs.py
@@ -132,7 +132,10 @@ class MultiSnifferInterface(AbstractInterface):
         self.devices = []
         if devices is None:
             for port in comports():
-                if port.vid == 0x0D28 and port.pid == 0x0204:
+                if type(port) is tuple:
+                    if "VID:PID=0d28:0204" in port[-1]:
+                        self.devices.append(port[0])
+                elif port.vid == 0x0D28 and port.pid == 0x0204:
                     self.devices.append(port.device)
         else:
             for device in devices:

--- a/btlejack/link.py
+++ b/btlejack/link.py
@@ -40,7 +40,11 @@ class Link(object):
         # if no interface is provided
         if interface is None:
             for port in comports():
-                if port.vid == 0x0D28 and port.pid == 0x0204:
+                if type(port) is tuple:
+                    if "VID:PID=0d28:0204" in port[-1]:
+                        interface = port[0]
+                        break
+                elif port.vid == 0x0D28 and port.pid == 0x0204:
                     interface = port.device
                     break
 


### PR DESCRIPTION
Fyi, on a Linux Mint host, pyserial on Python 3.4 when calling the comports function, it is returning a list of tuples of strings instead of a list of ListPortInfo objects.

This is kind of related to https://github.com/virtualabs/btlejack/issues/8

I fixed it by simply checking if port is of type tuple, and if yes, parse the tuple. Works fine on my Linux machine now.