### PR TITLE
Added __init__ before sniffing again after a connection loss.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -295,3 +295,8 @@ This cache can be flushed with the ``-z`` option:
 ::
 
   $ btlejack -z
+
+
+Hint for using btlejack on a Raspberry Pi
+-----------------------------------------
+If you have previously enabled **virtual ethernet over USB** (RNDIS), e.g. to setup a Raspberry Pi Zero W over USB, you need to disable this again (i.e. remove ``dtoverlay=dwc2`` from boot/config.txt and ``modules-load=dwc2,g_ether`` from boot/cmdline.txt, then ``sudo reboot``), because this would otherwise interfere with the sniffers' USB connections.

--- a/btlejack/ui.py
+++ b/btlejack/ui.py
@@ -437,7 +437,10 @@ class CLIConnectionSniffer(ConnectionSniffer):
         """
         Connection lost.
         """
-        print('[!] Connection lost, sniffing again...')
+        print('[!] Connection lost, initializing...')
+        super().__init__(self.bd_address)
+
+        print('[!] Sniffing again...')
         self.sniff()
 
 


### PR DESCRIPTION
I started to use btlejack on a Raspberry Pi 3 Model B+, which runs Raspbian Stretch Lite Version "November 2018", Release date 2018-11-13, Kernel version 4.14, 
with three micro:bit sniffers flashed to version 1.3.

Running `btlejack -c xx:xx:xx:xx:xx:xx` I found that it would always follow the first connection that I set up after the start, but after that connection was lost, most of the time, btlejack would not follow the next connection.

So I inserted a `super().__init__` call in `on_connection_lost()`, which solved this issue for me. btlejack now also follows all subsequent connections.

I'm not sure if this is the correct solution, i.e. if there are negative side-effects, or if there's a more elegant solution, but - well, it seems to work.