### PR TITLE
Added __init__ before sniffing again after a connection loss.

### DIFF
--- a/btlejack/ui.py
+++ b/btlejack/ui.py
@@ -438,6 +438,10 @@ class CLIConnectionSniffer(ConnectionSniffer):
         Connection lost.
         """
         print('[!] Connection lost, sniffing again...')
+        print('[!] Connection lost, initializing...')
+        super().__init__(self.bd_address)
+
+        print('[!] Sniffing again...')
         self.sniff()
 
 


### PR DESCRIPTION
(Note: I tried to submit this pull request before, see https://github.com/virtualabs/btlejack/pull/33 - but then inadvertently reverted this change again in https://github.com/virtualabs/btlejack/pull/35 . So here I go again...)

I started to use btlejack on a Raspberry Pi 3 Model B+, which runs Raspbian Stretch Lite Version "November 2018", Release date 2018-11-13, Kernel version 4.14,
with three micro:bit sniffers flashed to version 1.3.

Running btlejack -c xx:xx:xx:xx:xx:xx I found that it would always follow the first connection that I set up after the start, but after that connection was lost, most of the time, btlejack would not follow the next connection.

So I inserted a super().__init__ call in on_connection_lost(), which solved this issue for me. btlejack now also follows all subsequent connections.