### PR TITLE
When sniffing again, the active link must be cleared

### DIFF
--- a/btlejack/jobs.py
+++ b/btlejack/jobs.py
@@ -221,6 +221,8 @@ class MultiSnifferInterface(AbstractInterface):
         """
         Sniff a specific bd address on multiple channels.
         """
+
+        self.active_link = None
         channels = [37, 38, 39]
 
         # initialize jobs


### PR DESCRIPTION
Otherwise, we won't read from other devices than the active link