### PR TITLE
Write RSSI values into the pcap

### DIFF
--- a/btlejack/pcap.py
+++ b/btlejack/pcap.py
@@ -133,7 +133,7 @@ class PcapBlePHDRWriter(PcapBleWriter):
         payload_header = pack(
             '<BbbBIH',
             packet[2],
-            -40,
+            packet[3],
             -100,
             0,
             aa,


### PR DESCRIPTION
Hey,

This patch should write the packet rssi value in the pcap when using the `-x ll_phdr` flag rather than -40