### PR TITLE
Two bug fixes

### DIFF
--- a/btlejack/dissect/att.py
+++ b/btlejack/dissect/att.py
@@ -204,7 +204,7 @@ class WriteRequest(Attribute):
 
     @staticmethod
     def from_bytes(raw):
-        handle = unpack('<H', raw[1:])[0]
+        handle = unpack('<H', raw[1:3])[0]
         value = raw[3:]
         return WriteRequest(handle, value)
 

--- a/btlejack/supervisors.py
+++ b/btlejack/supervisors.py
@@ -525,7 +525,7 @@ class ConnectionSniffer(Supervisor):
                 else:
                     self.on_ll_packet(packet)
 
-    def on_connection(self, inita, adva, crc_init, interval, increment, channel_map):
+    def on_connection(self, inita, adva, crc_init, interval, increment, channel_map, timeout):
         print('Got connection !')
 
     def on_ll_packet(self, packet):


### PR DESCRIPTION
Hi,

first of all thank you for this great tool! I used it in one of my projects and it helps me to find a bug in a BLE smart lock.

While using your tool as a library and wrapping it with my code, I found two small bugs:

1. missing method argument
2. missing slice boundary

The **first** can be validated by looking at the implementation of `ConnectionSniffer`. In the method `on_packet_received` the method `on_connection` is called with a given timeout (`packet.timeout`):
https://github.com/virtualabs/btlejack/blob/c487859888450f6a33f618180bac5358f104e367/btlejack/supervisors.py#L501-L511

I know the `on_connection` function is a placeholder and should be overridden like in `CLIConnectionSniffer` anyway, but I think the interface should be the same. So I would add the timeout argument here:

https://github.com/virtualabs/btlejack/blob/c487859888450f6a33f618180bac5358f104e367/btlejack/supervisors.py#L528-L530

The **second** is an error during unpacking. Unpacking with `unpack('<H', raw[1:])[0]` of more than 2 bytes leads to `struct.error: unpack requires a buffer of 2 bytes`:
https://github.com/virtualabs/btlejack/blob/c487859888450f6a33f618180bac5358f104e367/btlejack/dissect/att.py#L205-L210

For the `WriteCommand` it was sliced correctly:
https://github.com/virtualabs/btlejack/blob/c487859888450f6a33f618180bac5358f104e367/btlejack/dissect/att.py#L221-L226

I assume that this behavior also occurs with other `from_bytes` implementations in the same module like `ExchangeMtuResponse`, `ExchangeMtuRequest` and `ErrorResponse`, but I am not 100% sure. Maybe some can confirm that?